### PR TITLE
Remove PUT and verification reference endpoints.

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -1,12 +1,8 @@
 openapi: 3.0.0
-# Added by API Auto Mocking Plugin
-servers:
-  - description: SwaggerHub API Auto Mocking
-    url: https://virtserver.swaggerhub.com/danubetech/credential-verifier/0.0.2
 info:
   description: This is an experimental open API specification for verifying digital credentials based on standards such as the Verifiable Credentials Data Model (https://www.w3.org/TR/vc-data-model/), JWT (https://tools.ietf.org/html/rfc7519), and Open Badges (https://openbadges.org/). Implementations are expected to change significantly and implementers that are not directly involved in the work are strongly urged to not implement this API. Implementations of this API may differ in terms of which data formats or proof formats they do or do not support. Implementations may choose to not support certain parts of this API (e.g. optional parts include retrieving a verification status that has already been created).
-  version: "0.0.2"
-  title: Credential Verifier API
+  version: "0.0.3"
+  title: Verifiable Credential Verifier HTTP API
   contact:
     email: markus@danubetech.com
   license:
@@ -104,57 +100,3 @@ paths:
                       "error": "The verificationMethod (public key) associated with the digital signature could not be retrieved due to a network error.",
                       "verificationMethod": "did:example:c6f1c276e12ec21ebfeb1f712eb#jf893k",
                     }]
-    put:
-      tags:
-        - internal
-      summary: Verifies a credential and returns its verification status.
-      operationId: verifyCredentialReference
-      description: Verifies a credential and returns its verification status. Support of this part of the API is OPTIONAL for implementations.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: The credential to be verified.
-      responses:
-        '201':
-          description: verification status successfully created!
-          content:
-            application/json:
-              schema:
-                type: object
-                description: The credential's verification status. This SHOULD include a reference or ID that can be used later for other parts of the API, e.g. retrieving a verification status that has already been created.
-        '400':
-          description: invalid input!
-        '500':
-          description: error!
-  /verifications/{verificationReference}:
-    get:
-      tags:
-        - internal
-      summary: Retrieves a verification status that has already been created, and returns it in the response body.
-      operationId: retrieveVerification
-      description: Retrieves a verification status that has already been created, and returns it in the response body. The retrieved verification status MUST be identical to the original verification status when it was first created. Support of this part of the API is OPTIONAL for implementations.
-      parameters:
-        - in: path
-          required: true
-          name: verificationReference
-          schema:
-            type: string
-          description: Reference to a verification status that has been created.
-      responses:
-        '200':
-          description: verification status successfully retrieved!
-          content:
-            application/json:
-              schema:
-                type: object
-                description: The retrieved verification status.
-        '400':
-          description: invalid input!
-        '404':
-          description: verification status not found!
-        '500':
-          description: error!
-        '501':
-          description: not supported by this implementation!


### PR DESCRIPTION
This PR implements a proposal from @peacekeeper and @msporny to remove the PUT and verification reference endpoints until we find a need for them:

https://github.com/w3c-ccg/vc-verifier-http-api/pull/7#issuecomment-598246060

* Remove PUT /verifications
* Remove POST /verifications/{verificationReference}
