### PR TITLE
Add ReSpec template for specification.

### DIFF
--- a/api.html
+++ b/api.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <!-- Load the latest Swagger UI code and style from npm using unpkg.com -->
+        <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+        <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css"/>
+        <title>vc-verifier-http-api</title>
+    </head>
+    <body>
+        <div id="swagger-ui"></div> <!-- Div to hold the UI component -->
+        <script>
+            window.onload = function () {
+                // Begin Swagger UI call region
+                const ui = SwaggerUIBundle({
+                    url: "api.yml",
+                    dom_id: '#swagger-ui',
+                    deepLinking: true,
+                    presets: [
+                        SwaggerUIBundle.presets.apis,
+                        SwaggerUIBundle.SwaggerUIStandalonePreset
+                    ],
+                    plugins: [
+                        SwaggerUIBundle.plugins.DownloadUrl
+                    ],
+                })
+                window.ui = ui
+            }
+        </script>
+    </body>
+</html>

--- a/common.js
+++ b/common.js
@@ -1,0 +1,327 @@
+/* globals omitTerms, respecConfig, $, require */
+/* exported linkCrossReferences, restrictReferences, fixIncludes */
+
+var ccg = {
+  // Add as the respecConfig localBiblio variable
+  // Extend or override global respec references
+  localBiblio: {
+    "REST": {
+      title: "Architectural Styles and the Design of Network-based Software Architectures",
+      date: "2000",
+      href: "http://www.ics.uci.edu/~fielding/pubs/dissertation/",
+      authors: [
+        "Fielding, Roy Thomas"
+      ],
+      publisher: "University of California, Irvine."
+    },
+    "VC-USECASES": {
+      title: "Verifiable Claims Use Cases",
+      href: "https://www.w3.org/TR/verifiable-claims-use-cases/",
+      authors: [
+      	"Shane McCarron",
+        "Daniel Burnett",
+        "Gregg Kellogg",
+        "Brian Sletten",
+        "Manu Sporny"
+      ],
+      status: "NOTE",
+      publisher: "Verifiable Claims Working Group"
+    },
+    "VC-EXTENSION-REGISTRY": {
+      title: "Verifiable Credentials Extension Registry",
+      href: "https://w3c-ccg.github.io/vc-extension-registry/",
+      authors: [
+        "Manu Sporny"
+      ],
+      status: "CG-DRAFT",
+      publisher: "Credentials Community Group"
+    },
+    "STRING-META": {
+      title: "Strings on the Web: Language and Direction Metadata",
+      href: "https://www.w3.org/TR/string-meta/",
+      authors: [
+        "Addison Phillips",
+        "Richard Ishida"
+      ],
+      status: "WD",
+      publisher: "Internationalization Working Group"
+    },
+    "LD-PROOFS": {
+      title: "Linked Data Proofs",
+      href: "https://w3c-dvcg.github.io/ld-proofs/",
+      authors: [
+        "Manu Sporny",
+        "Dave Longley"
+      ],
+      status: "CG-DRAFT",
+      publisher: "Digital Verification Community Group"
+    },
+    "LD-SIGNATURES": {
+      title: "Linked Data Signatures",
+      href: "https://w3c-dvcg.github.io/ld-signatures/",
+      authors: [
+        "Manu Sporny",
+        "Dave Longley"
+      ],
+      status: "CG-DRAFT",
+      publisher: "Digital Verification Community Group"
+    },
+    "LDS-RSA2018": {
+      title: "The 2018 RSA Linked Data Signature Suite",
+      href: "https://w3c-dvcg.github.io/lds-rsa2018/",
+      authors: [
+        "Manu Sporny",
+        "Dave Longley"
+      ],
+      status: "CG-DRAFT",
+      publisher: "Digital Verification Community Group"
+    },
+    "MULTIBASE": {
+      title: "Multibase",
+      href: "https://tools.ietf.org/html/draft-multiformats-multibase",
+      authors: [
+        "Juan Benet",
+        "Manu Sporny"
+      ],
+      status: "Independent Draft",
+      publisher: "IETF"
+    },
+    "MULTICODEC": {
+      title: "Multibase",
+      href: "https://github.com/multiformats/multicodec/blob/master/README.md",
+      authors: [
+        "Juan Benet",
+        "Manu Sporny"
+      ],
+      status: "Independent Draft",
+      publisher: "IETF"
+    },
+    "CL-SIGNATURES": {
+      title: "A Signature Scheme with Efficient Protocols",
+      href: "http://groups.csail.mit.edu/cis/pubs/lysyanskaya/cl02b.pdf",
+      authors: [
+        "Jan Camenisch",
+        "Anna Lysyanskaya"
+      ],
+      status: "Peer Reviewed Paper",
+      publisher: "IBM Research"
+    },
+    // aliases to known references
+    "HTTP-SIGNATURES": {
+      aliasOf: "http-signatures"
+    },
+    "MACAROONS": {
+      title: 'Macaroons',
+      // TODO: create spec
+      href: 'http://macaroons.io/',
+      authors: ['Arnar Birgisson', 'Joe Gibbs Politz', 'Úlfar Erlingsson',
+        'Ankur Taly', 'Michael Vrable', 'Mark Lentczner'],
+      status: 'unofficial',
+      publisher: 'Credentials Community Group'
+    },
+    'OPEN-BADGES': {
+      title: 'Open Badges',
+      href: 'https://github.com/openbadges/openbadges-specification',
+      authors: ['Brian Brennan', 'Mike Larsson', 'Chris McAvoy',
+        'Nate Otto', 'Kerri Lemoie'],
+      status:   'BA-DRAFT',
+      publisher:  'Badge Alliance Standard Working Group'
+    },
+    'RDF-NORMALIZATION': {
+      title: 'RDF Dataset Normalization',
+      href: 'http://json-ld.github.io/normalization/spec/',
+      authors: ['Dave Longley', 'Manu Sporny'],
+      status:   'CG-DRAFT',
+      publisher:  'Credentials W3C Community Group'
+    },
+    'DEMOGRAPHICS': {
+      title: 'Simple Demographics Often Identify People Uniquely',
+      href: 'http://dataprivacylab.org/projects/identifiability/paper1.pdf',
+      authors: ['Latanya Sweeney'],
+      publisher: 'Data Privacy Lab'
+    },
+    'VC-IMP-GUIDE': {
+      title: 'Verifiable Credentials Implementation Guidelines 1.0',
+      href: 'https://w3c.github.io/vc-imp-guide/',
+      authors: ['Andrei Sambra', 'Manu Sporny'],
+      status: 'ED',
+      publisher: 'Credentials Community Group'
+    },
+    'HASHLINK': {
+      title: 'Cryptographic Hyperlinks',
+      href: 'https://tools.ietf.org/html/draft-sporny-hashlink',
+      authors: ['Manu Sporny'],
+      status: 'Internet-Draft',
+      publisher: 'Internet Engineering Task Force (IETF)'
+    },
+    'IPFS': {
+      title: 'InterPlanetary File System (IPFS)',
+      href: 'https://en.wikipedia.org/wiki/InterPlanetary_File_System',
+      publisher: 'Wikipedia'
+    },
+    'JSON-SCHEMA-2018': {
+      title: 'JSON Schema: A Media Type for Describing JSON Documents',
+      href: 'https://tools.ietf.org/html/draft-handrews-json-schema',
+      authors: ['Austin Wright', 'Henry Andrews'],
+      status: 'Internet-Draft',
+      publisher: 'Internet Engineering Task Force (IETF)'
+    },
+    'JSON-LD': {
+      title: 'JSON-LD 1.1: A JSON-based Serialization for Linked Data',
+      href: 'https://www.w3.org/TR/json-ld11/',
+      authors: ['Gregg Kellogg', 'Manu Sporny', 'Dave Longley', 'Markus Lanthaler', 'Pierre-Antoine Champin', 'Niklas Lindström'],
+      status: 'WD',
+      publisher: 'W3C JSON-LD 1.1 Working Group'
+    }
+  }
+};
+
+
+
+// We should be able to remove terms that are not actually
+// referenced from the common definitions
+//
+// the termlist is in a block of class "termlist", so make sure that
+// has an ID and put that ID into the termLists array so we can
+// interrogate all of the included termlists later.
+var termNames = [] ;
+var termLists = [] ;
+var termsReferencedByTerms = [] ;
+
+function restrictReferences(utils, content) {
+    "use strict";
+    var base = document.createElement("div");
+    base.innerHTML = content;
+
+    // New new logic:
+    //
+    // 1. build a list of all term-internal references
+    // 2. When ready to process, for each reference INTO the terms,
+    // remove any terms they reference from the termNames array too.
+    $.each(base.querySelectorAll("dfn"), function(i, item) {
+        var $t = $(item) ;
+        var titles = $t.getDfnTitles();
+        var dropit = false;
+        // do we have an omitTerms
+        if (window.hasOwnProperty("omitTerms")) {
+            // search for a match
+            $.each(omitTerms, function(j, term) {
+                if (titles.indexOf(term) !== -1) {
+                    dropit = true;
+                }
+            });
+        }
+        // do we have an includeTerms
+        if (window.hasOwnProperty("includeTerms")) {
+            var found = false;
+            // search for a match
+            $.each(includeTerms, function(j, term) {
+                if (titles.indexOf(term) !== -1) {
+                    found = true;
+                }
+            });
+            if (!found) {
+                dropit = true;
+            }
+        }
+        if (dropit) {
+            $t.parent().next().remove();
+            $t.parent().remove();
+        } else {
+            var n = $t.makeID("dfn", titles[0]);
+            if (n) {
+                termNames[n] = $t.parent() ;
+            }
+        }
+    });
+
+    var $container = $(".termlist",base) ;
+    var containerID = $container.makeID("", "terms") ;
+    termLists.push(containerID) ;
+
+    return (base.innerHTML);
+}
+// add a handler to come in after all the definitions are resolved
+//
+// New logic: If the reference is within a 'dl' element of
+// class 'termlist', and if the target of that reference is
+// also within a 'dl' element of class 'termlist', then
+// consider it an internal reference and ignore it.
+
+require(["core/pubsubhub"], function(respecEvents) {
+    "use strict";
+    respecEvents.sub('end', function(message) {
+        if (message === 'core/link-to-dfn') {
+            // all definitions are linked; find any internal references
+            $(".termlist a.internalDFN").each(function() {
+                var $r = $(this);
+                var id = $r.attr('href');
+                var idref = id.replace(/^#/,"") ;
+                if (termNames[idref]) {
+                    // this is a reference to another term
+                    // what is the idref of THIS term?
+                    var $def = $r.closest('dd') ;
+                    if ($def.length) {
+                        var $p = $def.prev('dt').find('dfn') ;
+                        var tid = $p.attr('id') ;
+                        if (tid) {
+                            if (termsReferencedByTerms[tid]) {
+                                termsReferencedByTerms[tid].push(idref);
+                            } else {
+                                termsReferencedByTerms[tid] = [] ;
+                                termsReferencedByTerms[tid].push(idref);
+                            }
+                        }
+                    }
+                }
+            }) ;
+
+            // clearRefs is recursive.  Walk down the tree of
+            // references to ensure that all references are resolved.
+            var clearRefs = function(theTerm) {
+                if ( termsReferencedByTerms[theTerm] ) {
+                    $.each(termsReferencedByTerms[theTerm], function(i, item) {
+                        if (termNames[item]) {
+                            delete termNames[item];
+                            clearRefs(item);
+                        }
+                    });
+                }
+                // make sure this term doesn't get removed
+                if (termNames[theTerm]) {
+                    delete termNames[theTerm];
+                }
+            };
+
+            // now termsReferencedByTerms has ALL terms that
+            // reference other terms, and a list of the
+            // terms that they reference
+            $("a.internalDFN").each(function () {
+                var $item = $(this) ;
+                var t = $item.attr('href');
+                var r = t.replace(/^#/,"") ;
+                // if the item is outside the term list
+                if ( ! $item.closest('dl.termlist').length ) {
+                    clearRefs(r);
+                }
+            });
+
+            // delete any terms that were not referenced.
+            /*
+            Object.keys(termNames).forEach(function(term) {
+                var $p = $("#"+term) ;
+                if ($p) {
+                    var tList = $p.getDfnTitles();
+                    $p.parent().next().remove();
+                    $p.parent().remove() ;
+                    tList.forEach(function( item ) {
+                      console.log("CHECKING ITEM", item, respecConfig);
+                        if (respecConfig.definitionMap[item]) {
+                            delete respecConfig.definitionMap[item];
+                        }
+                    });
+                }
+            });*/
+        }
+    });
+});

--- a/index.html
+++ b/index.html
@@ -1,30 +1,219 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <!-- Load the latest Swagger UI code and style from npm using unpkg.com -->
-        <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
-        <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css"/>
-        <title>vc-verifier-http-api</title>
-    </head>
-    <body>
-        <div id="swagger-ui"></div> <!-- Div to hold the UI component -->
-        <script>
-            window.onload = function () {
-                // Begin Swagger UI call region
-                const ui = SwaggerUIBundle({
-                    url: "api.yml",
-                    dom_id: '#swagger-ui',
-                    deepLinking: true,
-                    presets: [
-                        SwaggerUIBundle.presets.apis,
-                        SwaggerUIBundle.SwaggerUIStandalonePreset
-                    ],
-                    plugins: [
-                        SwaggerUIBundle.plugins.DownloadUrl
-                    ],
-                })
-                window.ui = ui
-            }
-        </script>
-    </body>
+  <head>
+    <title>Verification HTTP API v0.4</title>
+    <meta http-equiv='Content-Type' content='text/html;charset=utf-8'/>
+    <!--
+      === NOTA BENE ===
+      For the three scripts below, if your spec resides on dev.w3 you can check them
+      out in the same tree and use relative links so that they'll work offline,
+     -->
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
+    <script src="./common.js" class="remove"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+    <script type="text/javascript" class="remove">
+      var respecConfig = {
+        // specification status (e.g., WD, LCWD, NOTE, etc.). If in doubt use ED.
+        specStatus: "ED",
+
+        // the specification's short name, as in http://www.w3.org/TR/short-name/
+        shortName: "vc-verifier-http-api",
+
+        // subtitle for the spec
+        subtitle: "An HTTP API for verifying W3C Verifiable Credentials.",
+
+        // if you wish the publication date to be other than today, set this
+        //publishDate: "",
+        //crEnd: "",
+        //prEnd: "",
+        //implementationReportURI: "",
+
+        // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
+        // and its maturity status
+        // previousPublishDate:  "1977-03-15",
+        // previousMaturity:  "WD",
+
+        // extend the bibliography entries
+        localBiblio: ccg.localBiblio,
+        doJsonLd: true,
+
+        github: "https://github.com/w3c-ccg/vc-verifier-http-api/",
+        includePermalinks: false,
+
+        // if there a publicly available Editor's Draft, this is the link
+        edDraftURI: "https://w3c-ccg.github.io/vc-verifier-http-api/",
+
+        // if this is a LCWD, uncomment and set the end of its review period
+        // lcEnd: "2009-08-05",
+
+        // editors, add as many as you like
+        // only "name" is required
+        editors: [
+          { name: "Markus Sabadello", url: "https://www.linkedin.com/in/markus-sabadello-353a0821/",
+            company: "Danube Tech", companyURL: "https://danubetech.com/"},
+          { name: "Manu Sporny", url: "https://www.linkedin.com/in/manusporny/",
+            company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/"}
+        ],
+        // authors, add as many as you like.
+        // This is optional, uncomment if you have authors as well as editors.
+        // only "name" is required. Same format as editors.
+        authors:
+        [
+          { name: "Markus Sabadello", url: "https://www.linkedin.com/in/markus-sabadello-353a0821/",
+            company: "Danube Tech", companyURL: "https://danubetech.com/"},
+          { name: "Manu Sporny", url: "https://digitalbazaar.com/",
+            company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/" }
+        ],
+        // name of the WG
+        wg:           "W3C Credentials Community Group",
+
+        // URI of the public WG page
+        wgURI:        "https://w3c-ccg.github.io/",
+
+        // name (with the @w3c.org) of the public mailing to which comments are due
+        wgPublicList: "public-credentials",
+
+        // URI of the patent status for this WG, for Rec-track documents
+        // !!!! IMPORTANT !!!!
+        // This is important for Rec-track documents, do not copy a patent URI from a random
+        // document unless you know what you're doing. If in doubt ask your friendly neighborhood
+        // Team Contact.
+        wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/98922/status",
+        maxTocLevel: 2,
+        inlineCSS: true
+      };
+    </script>
+    <script>
+window.onload = function () {
+  // Begin Swagger UI call region
+  const ui = SwaggerUIBundle({
+    url: "api.yml",
+    dom_id: '#swagger-ui',
+    deepLinking: true,
+    presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIBundle.SwaggerUIStandalonePreset
+    ],
+    plugins: [
+        SwaggerUIBundle.plugins.DownloadUrl
+    ],
+  })
+  window.ui = ui
+}
+    </script>
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css"/>
+    <style>
+pre .highlight {
+  font-weight: bold;
+  color: Green;
+}
+pre .subject {
+  font-weight: bold;
+  color: RoyalBlue;
+}
+pre .property {
+  font-weight: bold;
+  color: DarkGoldenrod;
+}
+pre .comment {
+  font-weight: bold;
+  color: SteelBlue;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.color-text {
+  font-weight: bold;
+  text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
+}
+    </style>
+  </head>
+  <body>
+    <section id='abstract'>
+      <p>
+An experimental open API specification for verifying digital credentials based
+on standards such as the Verifiable Credentials Data Model
+(https://www.w3.org/TR/vc-data-model/). Implementations are expected to change
+significantly and implementers that are not directly involved in the work are
+strongly urged to not implement this API. Implementations of this API may differ
+in terms of which data formats or proof formats they do or do not support.
+Implementations may choose to not support certain parts of this API (e.g.
+optional parts include retrieving a verification status that has already been
+created).
+      </p>
+    </section>
+
+    <section id='sotd'>
+
+      <p>
+Portions of the work on this specification have been funded by the
+United States Department of Homeland Security's Science and Technology
+Directorate under contract 70RSAT20T00000010. The content of this specification
+does not necessarily reflect the position or the policy of the U.S. Government
+and no official endorsement should be inferred.
+      </p>
+
+    </section>
+
+    <section class="informative">
+      <h2>Introduction</h2>
+
+      <p>
+        An experimental open API specification for verifying digital credentials based
+        on standards such as the Verifiable Credentials Data Model
+        (https://www.w3.org/TR/vc-data-model/). Implementations are expected to change
+        significantly and implementers that are not directly involved in the work are
+        strongly urged to not implement this API. Implementations of this API may differ
+        in terms of which data formats or proof formats they do or do not support.
+        Implementations may choose to not support certain parts of this API (e.g.
+        optional parts include retrieving a verification status that has already been
+        created).
+      </p>
+    </section>
+
+
+    <section class="normative">
+      <h2>Operations</h2>
+
+      <p>
+The following section outlines the HTTP operations.
+      </p>
+
+      <div id="swagger-ui"></div>
+
+    </section>
+
+    <section class="informative">
+      <h2>Security and Privacy Considerations</h2>
+
+      <p>
+There are a number of security and privacy considerations that implementers
+will want to take into consideration when implementing this specification.
+      </p>
+
+      <section class="informative">
+        <h3>TBD</h3>
+
+        <p>
+        </p>
+      </section>
+
+    </section>
+
+  </section>
+
+  <section class="appendix informative">
+    <h2>Acknowledgements</h2>
+
+    <p>
+The Working Group would like to thank the following individuals for reviewing
+and providing feedback on the specification (in alphabetical order):
+    </p>
+
+    <p>
+TBD...
+    </p>
+  </section>
+  </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,173 @@
+<p>
+The following terms are used to describe concepts in this specification.
+</p>
+
+<dl class="termlist">
+  <dt><dfn data-lt="claims">claim</dfn></dt>
+  <dd>
+An assertion made about a <a>subject</a>.
+  </dd>
+  <dt><dfn data-lt="credential|credentials">credential</dfn></dt>
+  <dd>
+A set of one or more <a>claims</a> made by an <a>issuer</a>. A
+<dfn data-lt="verifiable credentials">verifiable credential</dfn> is a
+tamper-evident credential that has authorship that can be cryptographically
+verified. Verifiable credentials can be used to build
+<a>verifiable presentations</a>, which can also be cryptographically verified.
+The <a>claims</a> in a credential can be about different <a>subjects</a>.
+  </dd>
+  <dt><dfn>data minimization</dfn></dt>
+  <dd>
+The act of limiting the amount of shared data strictly to the minimum
+necessary to successfully accomplish a task or goal.
+  </dd>
+  <dt><dfn data-lt="decentralized identifiers|DID|DIDs">decentralized identifier</dfn></dt>
+  <dd>
+A portable URL-based identifier, also known as a <strong><em>DID</em></strong>,
+associated with an <a>entity</a>. These identifiers are most often used in a
+<a>verifiable credential</a> and are associated with <a>subjects</a> such that a
+<a>verifiable credential</a> itself can be easily ported from one
+<a>repository</a> to another without the need to reissue the <a>credential</a>.
+An example of a DID is <code>did:example:123456abcdef</code>.
+  </dd>
+  <dt><dfn data-lt="decentralized identifier documents|DID document|DID documents">decentralized identifier document</dfn></dt>
+  <dd>
+Also referred to as a <strong><em>DID document</em></strong>, this is a document 
+that is accessible using a <a>verifiable data registry</a> and contains
+information related to a specific <a>decentralized identifier</a>, such as the
+associated <a>repository</a> and public key information.
+  </dd>
+  <dt><dfn data-lt="predicates|derived predicates">derived predicate</dfn></dt>
+  <dd>
+A verifiable, boolean assertion about the value of another attribute in a
+<a>verifiable credential</a>. These are useful in zero-knowledge-proof-style
+<a>verifiable presentations</a> because they can limit information disclosure.
+For example, if a <a>verifiable credential</a> contains an attribute
+for expressing a specific height in centimeters, a derived predicate
+might reference the height attribute in the <a>verifiable credential</a>
+demonstrating that the <a>issuer</a> attests to a height value meeting the
+minimum height requirement, without actually disclosing the specific height
+value. For example, the <a>subject</a> is taller than 150 centimeters.
+  </dd>
+  <dt><dfn>digital signature</dfn></dt>
+  <dd>
+A mathematical scheme for demonstrating the authenticity of a digital message.
+  </dd>
+  <dt><dfn data-lt="entities|entity's">entity</dfn></dt>
+  <dd>
+A thing with distinct and independent existence, such as a person,
+organization, or device that performs one or more roles in the ecosystem.
+  </dd>
+  <dt><dfn data-lt="graphs">graph</dfn></dt>
+  <dd>
+A network of information composed of <a>subjects</a> and their relationship
+to other <a>subjects</a> or data.
+  </dd>
+  <dt><dfn data-lt="holders|holder's|holders'">holder</dfn></dt>
+  <dd>
+A role an <a>entity</a> might perform by possessing one or more
+<a>verifiable credentials</a> and generating <a>presentations</a> from them.
+A holder is usually, but not always, a <a>subject</a> of the <a>verifiable
+credentials</a> they are holding. Holders store their <a>credentials</a> in
+<a>credential repositories</a>.
+  </dd>
+  <dt><dfn data-lt="identities|identity's">identity</dfn></dt>
+  <dd>
+The means for keeping track of <a>entities</a> across contexts. Digital
+identities enable tracking and customization of <a>entity</a> interactions
+across digital contexts, typically using identifiers and attributes. Unintended
+distribution or use of identity information can compromise privacy. Collection
+and use of such information should follow the principle of
+<a>data minimization</a>.
+  </dd>
+  <dt><dfn data-lt="identity providers|idp">identity provider</dfn></dt>
+  <dd>
+An identity provider, sometimes abbreviated as <em>IdP</em>, is a system
+for creating, maintaining, and managing identity information for
+<a>holders</a>, while providing authentication services to
+<a>relying party</a> applications within a federation or distributed network.
+In this case the <a>holder</a> is always the <a>subject</a>. Even if the
+<a>verifiable credentials</a> are bearer <a>credentials</a>, it is assumed the
+<a>verifiable credentials</a> remain with the <a>subject</a>, and if they are
+not, they were stolen by an attacker. This specification does not use this term
+unless comparing or mapping the concepts in this document to other
+specifications. This specification decouples the <a>identity provider</a>
+concept into two distinct concepts: the <a>issuer</a> and the <a>holder</a>.
+  </dd>
+  <dt><dfn data-lt="issuers|issuer's">issuer</dfn></dt>
+  <dd>
+A role an <a>entity</a> can perform by asserting <a>claims</a> about one or
+more <a>subjects</a>, creating a <a>verifiable credential</a> from these
+<a>claims</a>, and transmitting the <a>verifiable credential</a> to a
+<a>holder</a>.
+  </dd>
+  <dt><dfn data-lt="presentations">presentation</dfn></dt>
+  <dd>
+Data derived from one or more <a>verifiable credentials</a>, issued by one or
+more <a>issuers</a>, that is shared with a specific <a>verifier</a>. A
+<dfn data-lt="verifiable presentations">verifiable presentation</dfn>
+is a tamper-evident presentation encoded in such a way that authorship of the
+data can be trusted after a process of cryptographic verification. Certain
+types of verifiable presentations might contain data that is synthesized from,
+but do not contain, the original <a>verifiable credentials</a> (for example,
+zero-knowledge proofs).
+  </dd>
+  <dt><dfn data-lt="credential repository|credential repositories|repositories">repository</dfn></dt>
+  <dd>
+A program, such as a storage vault or personal <a>verifiable credential</a>
+wallet, that stores and protects access to <a>holders'</a>
+<a>verifiable credentials</a>.
+  </dd>
+  <dt><dfn>selective disclosure</dfn></dt>
+  <dd>
+The ability of a <a>holder</a> to make fine-grained decisions about what 
+information to share.
+  </dd>
+  <dt><dfn data-lt="subjects|subject's">subject</dfn></dt>
+  <dd>
+A thing about which <a>claims</a> are made.
+  </dd>
+  <dt><dfn>user agent</dfn></dt>
+  <dd>
+A program, such as a browser or other Web client, that mediates the
+communication between <a>holders</a>, <a>issuers</a>, and <a>verifiers</a>.
+  </dd>
+  <dt><dfn data-lt="credential validation">validation</dfn></dt>
+  <dd>
+The assurance that a <a>verifiable credential</a> or a
+<a>verifiable presentation</a> meets the needs of a <a>verifier</a> and other
+dependent stakeholders. This specification is constrained to <a>verifying</a>
+<a>verifiable credentials</a> and <a>verifiable presentations</a> regardless of
+their usage. Validating <a>verifiable credentials</a> or
+<a>verifiable presentations</a> is outside the scope of this specification.
+  </dd>
+  <dt><dfn data-lt="verifiable data registries">verifiable data registry</dfn></dt>
+  <dd>
+A role a system might perform by mediating the creation and <a>verification</a>
+of identifiers, keys, and other relevant data, such as
+<a>verifiable credential</a> schemas, revocation registries, issuer public keys,
+and so on, which might be required to use <a>verifiable credentials</a>. Some
+configurations might require correlatable identifiers for <a>subjects</a>. Some
+registries, such as ones for UUIDs and public keys, might just act as namespaces
+for identifiers.
+  </dd>
+  <dt><dfn data-lt="verify|verified|verifying|verifiable|verifiability">verification</dfn></dt>
+  <dd>
+The evaluation of whether a <a>verifiable credential</a> or <a>verifiable presentation</a> 
+is an authentic and timely statement of the issuer or presenter, respectively.  
+    This includes checking that: the credential (or presentation) conforms to the specification; the proof method is
+satisfied; and, if present, the status check succeeds.
+
+  </dd>
+  <dt><dfn data-lt="verifier|verifiers|verifier's|credential verifiers|credential verifier's">verifier</dfn></dt>
+  <dd>
+A role an <a>entity</a> performs by receiving one or more
+<a>verifiable credentials</a>, optionally inside a
+<a>verifiable presentation</a> for processing. Other specifications might refer
+to this concept as a <dfn data-lt="relying parties">relying party</dfn>.
+  </dd>
+  <dt><dfn data-lt="URI|URIs">URI</dfn></dt>
+  <dd>
+A Uniform Resource Identifier, as defined by [[RFC3986]].
+  </dd>
+</dl>

--- a/terms.html
+++ b/terms.html
@@ -32,7 +32,7 @@ An example of a DID is <code>did:example:123456abcdef</code>.
   </dd>
   <dt><dfn data-lt="decentralized identifier documents|DID document|DID documents">decentralized identifier document</dfn></dt>
   <dd>
-Also referred to as a <strong><em>DID document</em></strong>, this is a document 
+Also referred to as a <strong><em>DID document</em></strong>, this is a document
 that is accessible using a <a>verifiable data registry</a> and contains
 information related to a specific <a>decentralized identifier</a>, such as the
 associated <a>repository</a> and public key information.
@@ -120,7 +120,7 @@ wallet, that stores and protects access to <a>holders'</a>
   </dd>
   <dt><dfn>selective disclosure</dfn></dt>
   <dd>
-The ability of a <a>holder</a> to make fine-grained decisions about what 
+The ability of a <a>holder</a> to make fine-grained decisions about what
 information to share.
   </dd>
   <dt><dfn data-lt="subjects|subject's">subject</dfn></dt>
@@ -153,8 +153,8 @@ for identifiers.
   </dd>
   <dt><dfn data-lt="verify|verified|verifying|verifiable|verifiability">verification</dfn></dt>
   <dd>
-The evaluation of whether a <a>verifiable credential</a> or <a>verifiable presentation</a> 
-is an authentic and timely statement of the issuer or presenter, respectively.  
+The evaluation of whether a <a>verifiable credential</a> or <a>verifiable presentation</a>
+is an authentic and timely statement of the issuer or presenter, respectively.
     This includes checking that: the credential (or presentation) conforms to the specification; the proof method is
 satisfied; and, if present, the status check succeeds.
 


### PR DESCRIPTION
This PR adds a ReSpec file and various supporting files in preparation for marking up the API in an accepted W3C format.

It's a bit of a failed attempt... doesn't look like the Swagger rendering is going to be compatible with ReSpec (for a variety of Javascript-y and markup reasons). So, there is a separate api.html file that can be used to view the Swagger file as HTML... and the ReSpec document will eventually normatively define the API.